### PR TITLE
Fix multithreading issues

### DIFF
--- a/aiosmb/connection.py
+++ b/aiosmb/connection.py
@@ -146,7 +146,7 @@ class SMBConnection:
 		self.gssapi = gssapi
 		self.original_gssapi = copy.deepcopy(gssapi) #preserving a copy of the original
 		
-		self.target = target
+		self.target = copy.deepcopy(target)
 		
 		#######DONT CHANGE THIS
 		#use this for smb2 > self.supported_dialects = [NegotiateDialects.WILDCARD, NegotiateDialects.SMB202, NegotiateDialects.SMB210]


### PR DESCRIPTION
When attempting to multithread and have numerous clients connect out at the same time, `target` appears to be the only shared, mutable data currently. This will throw errors when attempting to connect to multiple hosts at the same time, as it will attempt to remove the wildcard here https://github.com/skelsec/aiosmb/blob/master/aiosmb/connection.py#L549 and throw an error when that no longer exists in the dictionary. Doing a deepcopy, as you did with the gssapi above, will solve this issue.

Here is a simplified script that you can use to repro (need to provide a list of hosts to connect to):

```py
import asyncio
from threading import Semaphore, Thread

from aiosmb.commons.connection.url import SMBConnectionURL
from aiosmb.commons.interfaces.machine import SMBMachine
from aiosmb.external.aiocmd.aiocmd import aiocmd

class SMBClient(aiocmd.PromptToolkitCmd):
    def __init__(self, url = None):
        aiocmd.PromptToolkitCmd.__init__(self, ignore_sigint=False)
        self.conn_url = SMBConnectionURL(url)
        self.connection = None
        self.machine = None

    async def do_login(self, url = None):
        """Connects to the remote machine"""
        try:
            cred = self.conn_url.get_credential()
            self.connection  = self.conn_url.get_connection()
            _, err = await self.connection.login()
            if err:
                raise err
            self.machine = SMBMachine(self.connection)
            return True, None
        except Exception as e:
            return False, e

async def run_enum(url_str, group_data, args):
    client = SMBClient(url=url_str)

    _,err = await client.do_login()
    if err:
        raise err

def enum_shares(connection_url, sem):

    sem.acquire()
    asyncio.run(run_enum(connection_url))
    sem.release()

def main():
    sem = Semaphore(20)

    for host in hosts:
        t = Thread(target=enum_shares, args=(connection_url, sem) 
        t.start()

```
Without this fix, it will throw a KeyError once per execution.