### PR TITLE
Add local group modification to smbclient via SAMR

### DIFF
--- a/aiosmb/commons/interfaces/machine.py
+++ b/aiosmb/commons/interfaces/machine.py
@@ -257,9 +257,10 @@ class SMBMachine:
 				raise Exception('No group found with name "%s"' % group_name)
 			
 			alias_handle, _ = await rr(self.named_rpcs['SAMR'].open_alias(domain_handle, target_group_rid))
-			targetsid = RPC_SID().fromCanonical(sid)
+			targetsid = RPC_SID()
+			targetsid.fromCanonical(sid)
 			result, _ = await rr(self.named_rpcs['SAMR'].add_member_to_alias(alias_handle, targetsid))
-
+			return result, None
 		except Exception as e:
 			return False, e		
 

--- a/aiosmb/commons/interfaces/machine.py
+++ b/aiosmb/commons/interfaces/machine.py
@@ -18,6 +18,7 @@ from aiosmb.dcerpc.v5.interfaces.rprnmgr import RPRNRPC
 from aiosmb.dcerpc.v5.interfaces.tschmgr import TSCHRPC
 from aiosmb.dcerpc.v5.interfaces.parmgr import PARRPC
 from aiosmb.dcerpc.v5.interfaces.wkstmgr import WKSTRPC
+from aiosmb.dcerpc.v5.dtypes import RPC_SID
 
 
 from aiosmb.dcerpc.v5 import tsch, scmr
@@ -235,7 +236,32 @@ class SMBMachine:
 		except Exception as e:
 			yield None, None, None, e
 
+	async def add_user_to_alias(self, domain_name, group_name, sid):
+		try:
+			_, err = await self.connect_rpc('SAMR')
+			if err is not None:
+				raise err
+			_, err = await self.connect_rpc('LSAD')
+			if err is not None:
+				raise err
+			policy_handle, _ = await rr(self.named_rpcs['LSAD'].open_policy2())
+			domain_sid, _ = await rr(self.named_rpcs['SAMR'].get_domain_sid(domain_name))
+			domain_handle, _ = await rr(self.named_rpcs['SAMR'].open_domain(domain_sid))
+			target_group_rid = None
+			async for name, rid, _ in rr_gen(self.named_rpcs['SAMR'].list_aliases(domain_handle)):
+				if name == group_name:
+					target_group_rid = rid
+					break
 
+			if target_group_rid is None:
+				raise Exception('No group found with name "%s"' % group_name)
+			
+			alias_handle, _ = await rr(self.named_rpcs['SAMR'].open_alias(domain_handle, target_group_rid))
+			targetsid = RPC_SID().fromCanonical(sid)
+			result, _ = await rr(self.named_rpcs['SAMR'].add_member_to_alias(alias_handle, targetsid))
+
+		except Exception as e:
+			return False, e		
 
 	async def list_directory(self, directory):
 		_, err = await directory.list(self.connection)
@@ -587,12 +613,12 @@ class SMBMachine:
 			logger.debug('Deleting temp file...')
 			_, err = await temp.delete()
 			if err is not None:
-				logger.debug('Failed to delete temp file!')
+				logger.warning('Failed to delete temp file!')
 
 			logger.debug('Deleting service...')
 			_, err = await self.delete_service(service_name)
 			if err is not None:
-				logger.debug('Failed to delete service!')
+				logger.warning('Failed to delete service!')
 			
 			yield None, None
 

--- a/aiosmb/dcerpc/v5/interfaces/samrmgr.py
+++ b/aiosmb/dcerpc/v5/interfaces/samrmgr.py
@@ -197,7 +197,17 @@ class SAMRRPC:
 				yield group['Name'], group_sid, None
 			enumerationContext = resp['EnumerationContext'] 
 			status = NTStatus(resp['ErrorCode'])
-			
+
+	@red	
+	async def add_member_to_alias(self, alias_handle, sid):
+		resp, err = await samr.hSamrAddMemberToAlias(self.dce, alias_handle, sid)
+		if err is not None:
+			if err.error_code != NTStatus.MORE_ENTRIES.value:
+				raise err
+			resp = err.get_packet()
+		status = NTStatus(resp['ErrorCode'])
+		return resp, None
+
 	@red_gen
 	async def enumerate_users(self, domain_handle):
 		status = NTStatus.MORE_ENTRIES

--- a/aiosmb/dcerpc/v5/interfaces/samrmgr.py
+++ b/aiosmb/dcerpc/v5/interfaces/samrmgr.py
@@ -206,7 +206,8 @@ class SAMRRPC:
 				raise err
 			resp = err.get_packet()
 		status = NTStatus(resp['ErrorCode'])
-		return resp, None
+		result = status == NTStatus.SUCCESS
+		return result, None
 
 	@red_gen
 	async def enumerate_users(self, domain_handle):

--- a/aiosmb/examples/smbclient.py
+++ b/aiosmb/examples/smbclient.py
@@ -288,8 +288,10 @@ class SMBClient(aiocmd.PromptToolkitCmd):
 			result, err = await self.machine.add_user_to_alias('Builtin', group_name, sid)
 			if err is not None:
 				raise err
+			if result:
+				print('Modification OK!')
 			else:
-				print(result)
+				print('Something went wrong, status != ok')
 			
 		except SMBException as e:
 			logger.debug(traceback.format_exc())

--- a/aiosmb/examples/smbclient.py
+++ b/aiosmb/examples/smbclient.py
@@ -282,6 +282,27 @@ class SMBClient(aiocmd.PromptToolkitCmd):
 		except Exception as e:
 			traceback.print_exc()
 
+	async def do_addsidtolocalgroup(self, group_name, sid):
+		"""Add member (by SID) to a local group"""
+		try:
+			result, err = await self.machine.add_user_to_alias('Builtin', group_name, sid)
+			if err is not None:
+				raise err
+			else:
+				print(result)
+			
+		except SMBException as e:
+			logger.debug(traceback.format_exc())
+			print(e.pprint())
+		except SMBMachineException as e:
+			logger.debug(traceback.format_exc())
+			print(str(e))
+		except DCERPCException as e:
+			logger.debug(traceback.format_exc())
+			print(str(e))
+		except Exception as e:
+			traceback.print_exc()
+
 	async def do_use(self, share_name):
 		"""selects share to be used"""
 		try:


### PR DESCRIPTION
Currently only by SID since that saves the need for manually resolving names. 

Also raised logging level to warning if temp file/service cannot be deleted after command execution, but feel free to change that back since it was more or less included in the commit by accident.