### PR TITLE
Fix SMBConnectionParams

### DIFF
--- a/aiosmb/commons/connection/credential.py
+++ b/aiosmb/commons/connection/credential.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+class SMBCredentialTypes(str, Enum):
+    NTLM_PASSWORD = "ntlm-password"
+    NTLM_NT = "ntlm-nt"
+    SSPI_NTLM = "sspi-ntlm"
+    KERBEROS_PASSWORD = "kerberos-password"
+    KERBEROS_NT = "kerberos-nt"
+    KERBEROS_PFX = "kerberos-pfx"
+    KERBEROS_PEM = "kerberos-pem"
+    SSPI_KERBEROS = "sspi-kerberos"
+    NEGOEX_PFX = "negoex-pfx"
+    NEGOEX_CERTSTORE = "negoex-certstore"

--- a/aiosmb/examples/smbreg.py
+++ b/aiosmb/examples/smbreg.py
@@ -6,7 +6,6 @@ from aiosmb.commons.connection.params import SMBConnectionParams
 from aiosmb.commons.connection.factory import SMBConnectionFactory
 from aiosmb.commons.interfaces.machine import SMBMachine
 from aiosmb.dcerpc.v5.common.service import ServiceStatus
-from aiosmb.external.aiocmd.aiocmd import aiocmd
 import enum
 
 class SMBREG_COMMAND(enum.Enum):
@@ -25,7 +24,7 @@ async def amain():
 	SMBConnectionParams.extend_parser(parser)
 	parser.add_argument('-v', '--verbose', action='count', default=0)
 	parser.add_argument('url', help='Connection URL base, target can be set to anything. Owerrides all parameter based connection settings! Example: "smb2+ntlm-password://TEST\\victim@test"')
-	parser.add_argument('commands', nargs='*', help = 'Commands in the following format: "r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest:Negotiate"')
+	parser.add_argument('commands', nargs='*', help = r'Commands in the following format: "r:HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest:Negotiate"')
 
 	args = parser.parse_args()
 


### PR DESCRIPTION
I want to use the smbreg example, but I notice that it contains an error in SMBConnectionParams due to a missing import of SMBCredentialTypes.